### PR TITLE
fix: Restrict NumPy to v1.x given PyTensor

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -70,7 +70,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.11.0-nompi_py312hedeef09_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py312hedeef09_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
@@ -121,8 +121,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-24_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.1-default_hb5137d0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.1-default_h9c6a7e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.2-default_hb5137d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.2-default_h9c6a7e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.10.1-hbbe4b11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
@@ -138,7 +138,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hd5240d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.1-h2ff4ddf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h77fa898_1.conda
@@ -153,7 +153,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.0-h04577a9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.0-h04577a9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
@@ -195,7 +195,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-hba22ea6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h56024de_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py312h7b63e92_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
@@ -307,9 +307,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6f/d3/1321715a95e856d4ef4fba24e4351cf5e4c89d459ad132a8cba5fe257d72/ml_dtypes-0.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c9/22/4638043e14493edf4101259f8fe05d9b5e6626c23d2ca96581a7ba298647/pymc-5.15.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2e/20/7344af23c762cf3a483a041c087f27bbf8b2a1a1ef3cec99154e9ca1bfd9/pytensor-2.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/7e/caaf95c63eda92bcc392d35716dbcd073dff58cec727790723d70e72240a/pymc-5.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/06/07/92f6e94c1ec6eea9e3acebc7c2767a7bbf1d4ebd320e4326aeb04c2eea9e/pytensor-2.25.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/67/91/5474b84e505a6ccc295b2d322d90ff6aa0746745717839ee0c5fb4fdcceb/rich-13.9.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
@@ -373,7 +374,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.11.0-nompi_py312h9a738b8_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.12.1-nompi_py312h9a738b8_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-9.0.0-hbf49d6b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_hd1676c9_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
@@ -424,8 +425,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.1.0-h86ecc28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-24_linuxaarch64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.1-default_he324ac1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.1-default_h4390ef5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.2-default_he324ac1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.2-default_h4390ef5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.10.1-h3ec0cbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.22-h86ecc28_0.conda
@@ -435,16 +436,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.3-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.1.0-he277a41_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he9431aa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.1.0-he9431aa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.1.0-he9431aa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.1.0-h9420597_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgl-1.7.0-hd24410f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.1-hc486b8e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglvnd-1.7.0-hd24410f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-24_linuxaarch64_openblas.conda
@@ -456,12 +457,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpciaccess-0.18-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.44-hc4a20ef_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.0-h081282e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.0-h081282e_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsodium-1.0.20-h68df207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.1-hc4a20ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.1.0-h3f4de04_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-hf1166c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.0-hec21d91_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
@@ -498,7 +499,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.44-h070dd5b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-10.4.0-py312h18c71c7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.0.0-py312h5ab5af3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
@@ -610,9 +611,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/75/bf571247bb3dbea73aa33ccae57ce322b9688003cfee2f68d303ab7b987b/ml_dtypes-0.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c9/22/4638043e14493edf4101259f8fe05d9b5e6626c23d2ca96581a7ba298647/pymc-5.15.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f4/f9/e2ba08de027e1ccc4bec8f3f383a144f3df7d54af4660cea8f2fac00597d/pytensor-2.20.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/8e/7e/caaf95c63eda92bcc392d35716dbcd073dff58cec727790723d70e72240a/pymc-5.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/11/032d9c2bb9bfa1b6d933c17a6fd063e075c533cca271d8c9b2055f94b981/pytensor-2.25.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/67/91/5474b84e505a6ccc295b2d322d90ff6aa0746745717839ee0c5fb4fdcceb/rich-13.9.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
@@ -663,7 +665,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.11.0-nompi_py312hf7df0ef_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.12.1-nompi_py312hf7df0ef_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h687a608_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
@@ -731,7 +733,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.17.0-hf1f96e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.1-hf78d878_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.2-hf78d878_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.1-py312hca98d7e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.2-py312hb401068_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py312h30cc4df_1.conda
@@ -755,7 +757,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312h683ea77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py312h66fe14f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
@@ -843,9 +845,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/b7/a067839f6e435785f34b09d96938dccb3a5d9502037de243cb84a2eb3f23/ml_dtypes-0.5.0-cp312-cp312-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c9/22/4638043e14493edf4101259f8fe05d9b5e6626c23d2ca96581a7ba298647/pymc-5.15.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2f/d5/5996fdaabb5db7b9e5a626675129837548834e67fde1e6018e494135dba9/pytensor-2.20.0-cp312-cp312-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/7e/caaf95c63eda92bcc392d35716dbcd073dff58cec727790723d70e72240a/pymc-5.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/99/f8f4a75e3287c48409dad5aa96336d10d76e9b4c9ebf5193b7436473ab2b/pytensor-2.25.5-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/67/91/5474b84e505a6ccc295b2d322d90ff6aa0746745717839ee0c5fb4fdcceb/rich-13.9.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.2.post1-pyhd8ed1ab_0.conda
@@ -895,7 +898,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h5netcdf-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.11.0-nompi_py312h3cd0824_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.12.1-nompi_py312h3cd0824_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_hec07895_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.6-pyhd8ed1ab_0.conda
@@ -963,7 +966,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.1-hb52a8e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.2-hb52a8e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.1-py312h906988d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.9.2-py312h1f38498_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.9.2-py312h9bd0bc6_1.conda
@@ -987,7 +990,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py312h8609ca0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py312haf37ca6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.21.0-pyhd8ed1ab_0.conda
@@ -1075,9 +1078,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/b7/a067839f6e435785f34b09d96938dccb3a5d9502037de243cb84a2eb3f23/ml_dtypes-0.5.0-cp312-cp312-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c9/22/4638043e14493edf4101259f8fe05d9b5e6626c23d2ca96581a7ba298647/pymc-5.15.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f4/f9/e2ba08de027e1ccc4bec8f3f383a144f3df7d54af4660cea8f2fac00597d/pytensor-2.20.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/8e/7e/caaf95c63eda92bcc392d35716dbcd073dff58cec727790723d70e72240a/pymc-5.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/11/032d9c2bb9bfa1b6d933c17a6fd063e075c533cca271d8c9b2055f94b981/pytensor-2.25.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/67/91/5474b84e505a6ccc295b2d322d90ff6aa0746745717839ee0c5fb4fdcceb/rich-13.9.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl
 packages:
 - kind: conda
@@ -3367,13 +3371,13 @@ packages:
   timestamp: 1728292541085
 - kind: conda
   name: h5py
-  version: 3.11.0
-  build: nompi_py312h3cd0824_103
-  build_number: 103
+  version: 3.12.1
+  build: nompi_py312h3cd0824_100
+  build_number: 100
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.11.0-nompi_py312h3cd0824_103.conda
-  sha256: eba937df39f1b0da2f116977de5e043a21044227058ab0013499f29218fe7ef5
-  md5: 830cd76fef2c93656223a8bada8daf87
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.12.1-nompi_py312h3cd0824_100.conda
+  sha256: 13a10000c055d7ecd1b163b2773ddd044231f6a0d34ca5654b7c5998f83f8112
+  md5: c68380e83d15943c51e9f85e939389d1
   depends:
   - __osx >=11.0
   - cached-property
@@ -3383,19 +3387,20 @@ packages:
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1177611
-  timestamp: 1728976217660
+  size: 1187242
+  timestamp: 1729117711331
 - kind: conda
   name: h5py
-  version: 3.11.0
-  build: nompi_py312h9a738b8_103
-  build_number: 103
+  version: 3.12.1
+  build: nompi_py312h9a738b8_100
+  build_number: 100
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.11.0-nompi_py312h9a738b8_103.conda
-  sha256: c38c876cb97db19ae96bf72e03eb942b0827abdd1d79b6eb6d3a4154fe00a4eb
-  md5: 0431c22343c5ce21f19a034ac03944fb
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.12.1-nompi_py312h9a738b8_100.conda
+  sha256: 839432401295624346bb62b323519eeee3470fa91cfebd20803f4eacb004ace1
+  md5: b4b2edf4018af3371c75765d70c1ddcd
   depends:
   - cached-property
   - hdf5 >=1.14.3,<1.14.4.0a0
@@ -3405,19 +3410,20 @@ packages:
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1352113
-  timestamp: 1728976202801
+  size: 1357823
+  timestamp: 1729117859900
 - kind: conda
   name: h5py
-  version: 3.11.0
-  build: nompi_py312hedeef09_103
-  build_number: 103
+  version: 3.12.1
+  build: nompi_py312hedeef09_100
+  build_number: 100
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.11.0-nompi_py312hedeef09_103.conda
-  sha256: 8a5ad781cde6df4e2d6a2a27593f44edf1986fe5a1554f3cbf8bc5e3bcdd83a9
-  md5: cec32e68634e4af17ef94d56a196d6ae
+  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.12.1-nompi_py312hedeef09_100.conda
+  sha256: c7d822b959e5506043cd8532f945d664a6a948f592f1dd7ec402b42a8153b974
+  md5: db0c97ee42647a9396d97e888f0ef258
   depends:
   - __glibc >=2.17,<3.0.a0
   - cached-property
@@ -3427,19 +3433,20 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1376258
-  timestamp: 1728976184813
+  size: 1382492
+  timestamp: 1729117750915
 - kind: conda
   name: h5py
-  version: 3.11.0
-  build: nompi_py312hf7df0ef_103
-  build_number: 103
+  version: 3.12.1
+  build: nompi_py312hf7df0ef_100
+  build_number: 100
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.11.0-nompi_py312hf7df0ef_103.conda
-  sha256: 15a750a8cfb72a629bafad52c2344533226b388cc46fb903f6fd697e08abc8cb
-  md5: 2a8ebc4a1bbc9d323b667644c7fb5b00
+  url: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.12.1-nompi_py312hf7df0ef_100.conda
+  sha256: 9aa71d54a706c4a17ebff3a1f8d14800e28b4ad73661f39653751ecc9eaf096f
+  md5: 4511be81b61ccb743208ac5c87820aab
   depends:
   - __osx >=10.13
   - cached-property
@@ -3448,10 +3455,11 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1160847
-  timestamp: 1728976212604
+  size: 1163612
+  timestamp: 1729117768585
 - kind: conda
   name: harfbuzz
   version: 9.0.0
@@ -5379,74 +5387,74 @@ packages:
   timestamp: 1726668809379
 - kind: conda
   name: libclang-cpp19.1
-  version: 19.1.1
+  version: 19.1.2
   build: default_hb5137d0_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.1-default_hb5137d0_0.conda
-  sha256: a2fb20bdcbebf94d654a4e770ddc910b0e1fcefe2b5acbd5dec04cb19129df2c
-  md5: a5feadc4a296e2d31ab5a642498ff85e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.2-default_hb5137d0_0.conda
+  sha256: faa3cbdf9ee65365eb5990b2687d964e84c3b646768d1aa60cf4ffe7b60c3ee9
+  md5: acf8651ac09d19641ab4356abfdf9321
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libllvm19 >=19.1.1,<19.2.0a0
+  - libllvm19 >=19.1.2,<19.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 20542477
-  timestamp: 1728456712882
+  size: 20513187
+  timestamp: 1729089419754
 - kind: conda
   name: libclang-cpp19.1
-  version: 19.1.1
+  version: 19.1.2
   build: default_he324ac1_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.1-default_he324ac1_0.conda
-  sha256: 43266a253bb6f1feef8f05805e538f9b130452a2bf71dec705dd7d255bb2059b
-  md5: 1619188f849e218ae50c46014ecb4667
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp19.1-19.1.2-default_he324ac1_0.conda
+  sha256: 3a7ad70238c3fd0ede0f1d3e637265ee69631b8252289a61d7501b3dfe944f8e
+  md5: b7cfe71cf7dbd97a8eb4d6e1b897707a
   depends:
   - libgcc >=13
-  - libllvm19 >=19.1.1,<19.2.0a0
+  - libllvm19 >=19.1.2,<19.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 20079186
-  timestamp: 1728459993311
+  size: 20098108
+  timestamp: 1729092339813
 - kind: conda
   name: libclang13
-  version: 19.1.1
+  version: 19.1.2
   build: default_h4390ef5_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.1-default_h4390ef5_0.conda
-  sha256: 491d941c45d9a82c6813d546d146acf1582d0c7fe0d63dd2c69f96dde60276ef
-  md5: b6f9600270f710d641e235f8820c4cb3
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-19.1.2-default_h4390ef5_0.conda
+  sha256: e8a41317df07438ec53e0cde8359e49079e2a323d47939f3a05cd23a8bb7ad8c
+  md5: e1add3117a4ef441fbce848afbf3e494
   depends:
   - libgcc >=13
-  - libllvm19 >=19.1.1,<19.2.0a0
+  - libllvm19 >=19.1.2,<19.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 11593940
-  timestamp: 1728460250441
+  size: 11635879
+  timestamp: 1729092584736
 - kind: conda
   name: libclang13
-  version: 19.1.1
+  version: 19.1.2
   build: default_h9c6a7e4_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.1-default_h9c6a7e4_0.conda
-  sha256: fa782c361fd77574cdd3e99762e82b8f02bc8b7da9098e8e5d5b925a153840fe
-  md5: 2e8992c584c2525a5b8ec7485cbe360c
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-19.1.2-default_h9c6a7e4_0.conda
+  sha256: 67da757df0c1ec71a2b2c5305e1c23eebb417109f07f98294a44c2278e99413c
+  md5: eadd021430638c34527abacac836fa15
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libllvm19 >=19.1.1,<19.2.0a0
+  - libllvm19 >=19.1.2,<19.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 11820007
-  timestamp: 1728456910135
+  size: 11818612
+  timestamp: 1729089619201
 - kind: conda
   name: libcups
   version: 2.3.3
@@ -5982,25 +5990,6 @@ packages:
   timestamp: 1636488182923
 - kind: conda
   name: libgcc
-  version: 14.1.0
-  build: he277a41_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.1.0-he277a41_1.conda
-  sha256: 0affee19a50081827a9b7d5a43a1d241d295209342f5c6b8d1da21e950547680
-  md5: 2cb475709e327bb76f74645784582e6a
-  depends:
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==14.1.0=*_1
-  - libgomp 14.1.0 he277a41_1
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 533503
-  timestamp: 1724802540921
-- kind: conda
-  name: libgcc
   version: 14.2.0
   build: h77fa898_1
   build_number: 1
@@ -6015,25 +6004,29 @@ packages:
   - libgomp 14.2.0 h77fa898_1
   - libgcc-ng ==14.2.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
   size: 848745
   timestamp: 1729027721139
 - kind: conda
-  name: libgcc-ng
-  version: 14.1.0
-  build: he9431aa_1
+  name: libgcc
+  version: 14.2.0
+  build: he277a41_1
   build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he9431aa_1.conda
-  sha256: 44e76a6c1fad613d92035c69e475ccb7da2f554b2fdfabceff8dc4bc570f3622
-  md5: 842a1a0cf6f995091734a723e5d291ef
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-14.2.0-he277a41_1.conda
+  sha256: 5d56757ccad208c79214395b00d006d8d18929a4ba49c47bd9460789a7620943
+  md5: 511b511c5445e324066c3377481bcab8
   depends:
-  - libgcc 14.1.0 he277a41_1
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==14.2.0=*_1
+  - libgomp 14.2.0 he277a41_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 52203
-  timestamp: 1724802545317
+  size: 535243
+  timestamp: 1729089435134
 - kind: conda
   name: libgcc-ng
   version: 14.2.0
@@ -6046,9 +6039,26 @@ packages:
   depends:
   - libgcc 14.2.0 h77fa898_1
   license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
   size: 54142
   timestamp: 1729027726517
+- kind: conda
+  name: libgcc-ng
+  version: 14.2.0
+  build: he9431aa_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.2.0-he9431aa_1.conda
+  sha256: 9b5cf168a6c7361cae869cb74b716766ee7c6d6b3f6172b32ba9bf91135efdc4
+  md5: 0694c249c61469f2c0f7e2990782af21
+  depends:
+  - libgcc 14.2.0 he277a41_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 54104
+  timestamp: 1729089444587
 - kind: conda
   name: libgfortran
   version: 5.0.0
@@ -6083,24 +6093,6 @@ packages:
   timestamp: 1707330749033
 - kind: conda
   name: libgfortran
-  version: 14.1.0
-  build: he9431aa_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.1.0-he9431aa_1.conda
-  sha256: 8632662e780c32b7eda20be8d56bb605fa5a4f7851ba5b86d1cdf17125327664
-  md5: c0b5e52811ae0997f9df25a99846eb9e
-  depends:
-  - libgfortran5 14.1.0 h9420597_1
-  constrains:
-  - libgfortran-ng ==14.1.0=*_1
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 52176
-  timestamp: 1724802573193
-- kind: conda
-  name: libgfortran
   version: 14.2.0
   build: h69a702a_1
   build_number: 1
@@ -6113,25 +6105,28 @@ packages:
   constrains:
   - libgfortran-ng ==14.2.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
   size: 53997
   timestamp: 1729027752995
 - kind: conda
-  name: libgfortran-ng
-  version: 14.1.0
+  name: libgfortran
+  version: 14.2.0
   build: he9431aa_1
   build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.1.0-he9431aa_1.conda
-  sha256: b0e32c07e8a2965f12950a793dece8ca08db83ecf88c76e0d0d2466cc35a8956
-  md5: 494514d173c7a4eb00957dc203b4d784
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-14.2.0-he9431aa_1.conda
+  sha256: cb66e411fa32a5c6040f4e5e2a63c00897aae4c3133a9c004c2e929ccf19575b
+  md5: 0294b92d2f47a240bebb1e3336b495f1
   depends:
-  - libgfortran 14.1.0 he9431aa_1
+  - libgfortran5 14.2.0 hb6113d0_1
+  constrains:
+  - libgfortran-ng ==14.2.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 52219
-  timestamp: 1724802763203
+  size: 54105
+  timestamp: 1729089471124
 - kind: conda
   name: libgfortran-ng
   version: 14.2.0
@@ -6144,9 +6139,26 @@ packages:
   depends:
   - libgfortran 14.2.0 h69a702a_1
   license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
   size: 54106
   timestamp: 1729027945817
+- kind: conda
+  name: libgfortran-ng
+  version: 14.2.0
+  build: he9431aa_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.2.0-he9431aa_1.conda
+  sha256: cdd5bae1e33d6bdafe837c2e6ea594faf5bb7f880272ac1984468c7967adff41
+  md5: 5e90005d310d69708ba0aa7f4fed1de6
+  depends:
+  - libgfortran 14.2.0 he9431aa_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 54111
+  timestamp: 1729089714658
 - kind: conda
   name: libgfortran5
   version: 13.2.0
@@ -6185,22 +6197,22 @@ packages:
   timestamp: 1707330687590
 - kind: conda
   name: libgfortran5
-  version: 14.1.0
-  build: h9420597_1
+  version: 14.2.0
+  build: hb6113d0_1
   build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.1.0-h9420597_1.conda
-  sha256: 1c455a32c1f5aaf9befd03894cc053271f0aea3fb4211bb91dd0055138dc09e4
-  md5: f30cf31e474062ea51481d4181ee15df
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.2.0-hb6113d0_1.conda
+  sha256: a87ff46d19916403cbf68cf1d785bf56b4d1ab7b2552468d2ea775d70782493f
+  md5: fc068e11b10e18f184e027782baa12b6
   depends:
-  - libgcc >=14.1.0
+  - libgcc >=14.2.0
   constrains:
-  - libgfortran 14.1.0
+  - libgfortran 14.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 1100985
-  timestamp: 1724802553945
+  size: 1102158
+  timestamp: 1729089452640
 - kind: conda
   name: libgfortran5
   version: 14.2.0
@@ -6215,6 +6227,7 @@ packages:
   constrains:
   - libgfortran 14.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
   size: 1462645
   timestamp: 1729027735353
@@ -6253,13 +6266,12 @@ packages:
   timestamp: 1727968574647
 - kind: conda
   name: libglib
-  version: 2.82.1
-  build: h2ff4ddf_1
-  build_number: 1
+  version: 2.82.2
+  build: h2ff4ddf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.1-h2ff4ddf_1.conda
-  sha256: 17eaf179e98847dd834aae75c74753e98026ee5ac818550185896b3b7bc6e76f
-  md5: 23b2601708f7fd71ceb52b4da41cdd66
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.82.2-h2ff4ddf_0.conda
+  sha256: 49ee9401d483a76423461c50dcd37f91d070efaec7e4dc2828d8cdd2ce694231
+  md5: 13e8e54035ddd2b91875ba399f0f7c04
   depends:
   - __glibc >=2.17,<3.0.a0
   - libffi >=3.4,<4.0a0
@@ -6268,20 +6280,19 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - pcre2 >=10.44,<10.45.0a0
   constrains:
-  - glib 2.82.1 *_1
+  - glib 2.82.2 *_0
   license: LGPL-2.1-or-later
   purls: []
-  size: 3957261
-  timestamp: 1728938307811
+  size: 3931898
+  timestamp: 1729191404130
 - kind: conda
   name: libglib
-  version: 2.82.1
-  build: hc486b8e_1
-  build_number: 1
+  version: 2.82.2
+  build: hc486b8e_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.1-hc486b8e_1.conda
-  sha256: 8172feb1dcc7d1f202d75d92c8208a01e5164907bbeb04cb1801e49599460713
-  md5: 4fc2dfe05f7c6c1bf1121353a39ec1f7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.82.2-hc486b8e_0.conda
+  sha256: 6797d24de7acd298f81a86078c64e4f3fea6d551a3e8892205c9e72a37a7cc3c
+  md5: 47f6d85fe47b865e56c539f2ba5f4dad
   depends:
   - libffi >=3.4,<4.0a0
   - libgcc >=13
@@ -6289,11 +6300,11 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - pcre2 >=10.44,<10.45.0a0
   constrains:
-  - glib 2.82.1 *_1
+  - glib 2.82.2 *_0
   license: LGPL-2.1-or-later
   purls: []
-  size: 4032190
-  timestamp: 1728938351635
+  size: 4020802
+  timestamp: 1729191545578
 - kind: conda
   name: libglvnd
   version: 1.7.0
@@ -6357,20 +6368,6 @@ packages:
   timestamp: 1727968567627
 - kind: conda
   name: libgomp
-  version: 14.1.0
-  build: he277a41_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_1.conda
-  sha256: a257997cc35b97a58b4b3be1b108791619736d90af8d30dab717d0f0dd835ab5
-  md5: 59d463d51eda114031e52667843f9665
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 461429
-  timestamp: 1724802428910
-- kind: conda
-  name: libgomp
   version: 14.2.0
   build: h77fa898_1
   build_number: 1
@@ -6381,9 +6378,24 @@ packages:
   depends:
   - _libgcc_mutex 0.1 conda_forge
   license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
   size: 460992
   timestamp: 1729027639220
+- kind: conda
+  name: libgomp
+  version: 14.2.0
+  build: he277a41_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.2.0-he277a41_1.conda
+  sha256: 5aa53874a5e57a00f2e0c2e2910684eb674429cd5fcb803619b226a73e89aedf
+  md5: 376f0e73abbda6d23c0cb749adc195ef
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 463521
+  timestamp: 1729089357313
 - kind: conda
   name: libiconv
   version: '1.17'
@@ -6952,12 +6964,12 @@ packages:
 - kind: conda
   name: libpq
   version: '17.0'
-  build: h04577a9_3
-  build_number: 3
+  build: h04577a9_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.0-h04577a9_3.conda
-  sha256: b0eb7ad8a8acf16bf85ca2e054fe292d42f80e9090aa6cfec06c065ee7978048
-  md5: ef53fcce61bbef374129547796e7dff7
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.0-h04577a9_4.conda
+  sha256: 2f7e72e32f495cfb0492b8091d97dbe1c0700428fe167f3a781bb46e88dee4e5
+  md5: 392cae2a58fbcb9db8c2147c6d6d1620
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=75.1,<76.0a0
@@ -6967,17 +6979,17 @@ packages:
   - openssl >=3.3.2,<4.0a0
   license: PostgreSQL
   purls: []
-  size: 2597099
-  timestamp: 1728977997781
+  size: 2602277
+  timestamp: 1729085182543
 - kind: conda
   name: libpq
   version: '17.0'
-  build: h081282e_3
-  build_number: 3
+  build: h081282e_4
+  build_number: 4
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.0-h081282e_3.conda
-  sha256: 2de984513c0dc7e2d28f4d56da2cf81ff5622d0a3122b66e48dac91322d1a57e
-  md5: 17a3e5d10c82631ce142bde55869dcfb
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-17.0-h081282e_4.conda
+  sha256: 346a576c7af087fe6ebb74c04d20c36c81e7d01e5c2ac688f780005530fa4c72
+  md5: 4627c6a062463cf4191aafca4d6c748c
   depends:
   - icu >=75.1,<76.0a0
   - krb5 >=1.21.3,<1.22.0a0
@@ -6986,8 +6998,8 @@ packages:
   - openssl >=3.3.2,<4.0a0
   license: PostgreSQL
   purls: []
-  size: 2700033
-  timestamp: 1728978238381
+  size: 2628843
+  timestamp: 1729085132846
 - kind: conda
   name: libsodium
   version: 1.0.20
@@ -7173,20 +7185,20 @@ packages:
   timestamp: 1685837820566
 - kind: conda
   name: libstdcxx
-  version: 14.1.0
+  version: 14.2.0
   build: h3f4de04_1
   build_number: 1
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.1.0-h3f4de04_1.conda
-  sha256: 430e7c36ca9736d06fd669eb1771acb9a8bcaac578ae76b093fa06391798a0ae
-  md5: 6c2afef2109372440a90c566bcb6391c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
+  sha256: 519556d2c93f1b487091ce046d62e762286177f4a670ec10e16005177d0bcab3
+  md5: 37f489acd39e22b623d2d1e5ac6d195c
   depends:
-  - libgcc 14.1.0 he277a41_1
+  - libgcc 14.2.0 he277a41_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 3808995
-  timestamp: 1724802564657
+  size: 3816794
+  timestamp: 1729089463404
 - kind: conda
   name: libstdcxx
   version: 14.2.0
@@ -7199,25 +7211,10 @@ packages:
   depends:
   - libgcc 14.2.0 h77fa898_1
   license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
   size: 3893695
   timestamp: 1729027746910
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.1.0
-  build: hf1166c9_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-hf1166c9_1.conda
-  sha256: d7aa6fa26735317ea5cc18e4c2f3316ce29dcc283d65b72b3b99b2d88386aaf4
-  md5: 51f54efdd1d2ed5d7e9c67381b75fdb1
-  depends:
-  - libstdcxx 14.1.0 h3f4de04_1
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 52240
-  timestamp: 1724802596264
 - kind: conda
   name: libstdcxx-ng
   version: 14.2.0
@@ -7230,9 +7227,26 @@ packages:
   depends:
   - libstdcxx 14.2.0 hc0a3c3a_1
   license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
   purls: []
   size: 54105
   timestamp: 1729027780628
+- kind: conda
+  name: libstdcxx-ng
+  version: 14.2.0
+  build: hf1166c9_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
+  sha256: 9f97461bd55a2745a7a0941f3502a047f15bfe7bb2952dc7fb204b3202f866fd
+  md5: 0e75771b8a03afae5a2c6ce71bc733f5
+  depends:
+  - libstdcxx 14.2.0 h3f4de04_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 54133
+  timestamp: 1729089498541
 - kind: conda
   name: libtiff
   version: 4.7.0
@@ -7713,40 +7727,38 @@ packages:
   timestamp: 1727963183990
 - kind: conda
   name: llvm-openmp
-  version: 19.1.1
-  build: hb52a8e5_1
-  build_number: 1
+  version: 19.1.2
+  build: hb52a8e5_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.1-hb52a8e5_1.conda
-  sha256: bac90d68cd6a1b5f0ae21e900715d425b02a3be8f6199a5e2dbcb126d8525a6e
-  md5: 6eab363cb011e739cf6f3bb92b763525
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.2-hb52a8e5_0.conda
+  sha256: a1836fa9eddf8b3fa2209db4a3423b13fdff93a8eacc9fe8360a6867e7f440d0
+  md5: 7ad59f95f091ed6a99a7cbcd6f201be0
   depends:
   - __osx >=11.0
   constrains:
-  - openmp 19.1.1|19.1.1.*
+  - openmp 19.1.2|19.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 280001
-  timestamp: 1728961638301
+  size: 280737
+  timestamp: 1729145191646
 - kind: conda
   name: llvm-openmp
-  version: 19.1.1
-  build: hf78d878_1
-  build_number: 1
+  version: 19.1.2
+  build: hf78d878_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.1-hf78d878_1.conda
-  sha256: b5800c43c3031095dbfd0e1d0bce39369a450ea60e3e64457b60ae3d8f207757
-  md5: d22a59378882a4985d7c0d9b821739a7
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.2-hf78d878_0.conda
+  sha256: 92231d391886bca0c0dabb42f02a37e7acb8ea84399843173fe8c294814735dd
+  md5: ca5f963676a9ad5383b7441368e1d107
   depends:
   - __osx >=10.13
   constrains:
-  - openmp 19.1.1|19.1.1.*
+  - openmp 19.1.2|19.1.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 305033
-  timestamp: 1728961695895
+  size: 305589
+  timestamp: 1729145249496
 - kind: pypi
   name: logical-unification
   version: 0.4.6
@@ -9017,21 +9029,20 @@ packages:
   timestamp: 1602536313357
 - kind: conda
   name: pillow
-  version: 10.4.0
-  build: py312h18c71c7_1
-  build_number: 1
+  version: 11.0.0
+  build: py312h5ab5af3_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-10.4.0-py312h18c71c7_1.conda
-  sha256: f4609aad2a4857293330a7de17dd35dc001acf6aefc53fe36f0a47eeb965840a
-  md5: 97c17230c0f6b6141a004921be48971a
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-11.0.0-py312h5ab5af3_0.conda
+  sha256: 3cf43a5eb1f67f3a5f3ef1ec3a685f8767019cce24dbe46c4b76fee8a54fbacf
+  md5: 1c4bdfe659cfdedd372685ce2494e97b
   depends:
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
   - libgcc >=13
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.8.0a0
+  - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.4.0,<2.0a0
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.17.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
   - python >=3.12,<3.13.0a0
@@ -9040,26 +9051,51 @@ packages:
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 42052988
-  timestamp: 1726076738535
+  size: 41756471
+  timestamp: 1729068045876
 - kind: conda
   name: pillow
-  version: 10.4.0
-  build: py312h56024de_1
-  build_number: 1
+  version: 11.0.0
+  build: py312h66fe14f_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.0.0-py312h66fe14f_0.conda
+  sha256: 5e531eded0bb784c745abe3a1187c6c33478e153755bf8a8496aebff60801150
+  md5: 1e49b81b5aae7af9d74bcdac0cd0d174
+  depends:
+  - __osx >=10.13
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  purls:
+  - pkg:pypi/pillow?source=hash-mapping
+  size: 42189378
+  timestamp: 1729065985392
+- kind: conda
+  name: pillow
+  version: 11.0.0
+  build: py312h7b63e92_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h56024de_1.conda
-  sha256: a0961e7ff663d4c7a82478ff45fba72a346070f2a017a9b56daff279c0dbb8e2
-  md5: 4bd6077376c7f9c1ce33fd8319069e5b
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.0.0-py312h7b63e92_0.conda
+  sha256: 13a464bea02c0df0199c20ef6bad24a6bc336aaf55bf8d6a133d0fe664463224
+  md5: 385f46a4df6f97892503a841121a9acf
   depends:
   - __glibc >=2.17,<3.0.a0
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
   - libgcc >=13
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.8.0a0
+  - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.4.0,<2.0a0
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.17.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
   - python >=3.12,<3.13.0a0
@@ -9068,52 +9104,24 @@ packages:
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 42689452
-  timestamp: 1726075285193
+  size: 41948418
+  timestamp: 1729065846594
 - kind: conda
   name: pillow
-  version: 10.4.0
-  build: py312h683ea77_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312h683ea77_1.conda
-  sha256: 1e8d489190aa0b4682f52468efe4db46b37e50679c64879696e42578c9a283a4
-  md5: fb17ec3065f089dad64d9b597b1e8ce4
-  depends:
-  - __osx >=10.13
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libxcb >=1.16,<2.0.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tk >=8.6.13,<8.7.0a0
-  license: HPND
-  purls:
-  - pkg:pypi/pillow?source=hash-mapping
-  size: 42329265
-  timestamp: 1726075276862
-- kind: conda
-  name: pillow
-  version: 10.4.0
-  build: py312h8609ca0_1
-  build_number: 1
+  version: 11.0.0
+  build: py312haf37ca6_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.4.0-py312h8609ca0_1.conda
-  sha256: 980139e8dfc9da20a96a6260c796eb7c77c5c5658ee4032f33ebe0ac980b2e2b
-  md5: b71f08e05207fa6a9155e8581c3d473e
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.0.0-py312haf37ca6_0.conda
+  sha256: 727b4c3faecdb6f6809cf20c5f32d2df4af34e0d5b9146b7588383bcba7990e8
+  md5: dc9b51fbd2b6f7fea9b5123458864dbb
   depends:
   - __osx >=11.0
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.8.0a0
+  - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.4.0,<2.0a0
-  - libxcb >=1.16,<2.0.0a0
+  - libxcb >=1.17.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
   - python >=3.12,<3.13.0a0
@@ -9123,8 +9131,8 @@ packages:
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 42413280
-  timestamp: 1726075422684
+  size: 41737424
+  timestamp: 1729065920347
 - kind: conda
   name: pixman
   version: 0.43.2
@@ -9484,18 +9492,19 @@ packages:
   timestamp: 1727852253970
 - kind: pypi
   name: pymc
-  version: 5.15.0
-  url: https://files.pythonhosted.org/packages/c9/22/4638043e14493edf4101259f8fe05d9b5e6626c23d2ca96581a7ba298647/pymc-5.15.0-py3-none-any.whl
-  sha256: 30bf59023912ea5f376b8381f3499e1a2ff0d1a23e9db8de1309c38d5570845e
+  version: 5.17.0
+  url: https://files.pythonhosted.org/packages/8e/7e/caaf95c63eda92bcc392d35716dbcd073dff58cec727790723d70e72240a/pymc-5.17.0-py3-none-any.whl
+  sha256: 1f6614589ab9095e79a98afb8bf173ea9810b4439591649e282708e3589c95e9
   requires_dist:
   - arviz>=0.13.0
   - cachetools>=4.2.1
   - cloudpickle
   - numpy>=1.15.0
   - pandas>=0.24.0
-  - pytensor<2.21,>=2.20
+  - pytensor<2.26,>=2.25.1
   - rich>=13.7.1
   - scipy>=1.4.1
+  - threadpoolctl<4.0.0,>=3.1.0
   - typing-extensions>=3.7.4
   requires_python: '>=3.10'
 - kind: conda
@@ -9626,6 +9635,7 @@ packages:
   - qt6-main 6.8.0.*
   - qt6-main >=6.8.0,<6.9.0a0
   license: LGPL-3.0-only
+  license_family: LGPL
   purls:
   - pkg:pypi/pyside6?source=hash-mapping
   - pkg:pypi/shiboken6?source=hash-mapping
@@ -9654,6 +9664,7 @@ packages:
   - qt6-main 6.8.0.*
   - qt6-main >=6.8.0,<6.9.0a0
   license: LGPL-3.0-only
+  license_family: LGPL
   purls:
   - pkg:pypi/pyside6?source=hash-mapping
   - pkg:pypi/shiboken6?source=hash-mapping
@@ -9680,19 +9691,18 @@ packages:
   timestamp: 1661604969727
 - kind: pypi
   name: pytensor
-  version: 2.20.0
-  url: https://files.pythonhosted.org/packages/2e/20/7344af23c762cf3a483a041c087f27bbf8b2a1a1ef3cec99154e9ca1bfd9/pytensor-2.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 3591171bb337601b855528e48f163b4032ce02c4b44696fc98871970820f8793
+  version: 2.25.5
+  url: https://files.pythonhosted.org/packages/06/07/92f6e94c1ec6eea9e3acebc7c2767a7bbf1d4ebd320e4326aeb04c2eea9e/pytensor-2.25.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 9c99f2aed904178c59fac57f5a760b547f7c1c14c20d31e41721fbebf9e47cf1
   requires_dist:
-  - setuptools>=48.0.0
-  - scipy>=0.14
-  - numpy>=1.17.0
-  - filelock
+  - setuptools>=59.0.0
+  - scipy<2,>=1
+  - numpy<2,>=1.17.0
+  - filelock>=3.15
   - etuples
   - logical-unification
   - minikanren
   - cons
-  - typing-extensions
   - pytensor[jax] ; extra == 'complete'
   - pytensor[numba] ; extra == 'complete'
   - pytensor[complete] ; extra == 'development'
@@ -9701,6 +9711,7 @@ packages:
   - jax ; extra == 'jax'
   - jaxlib ; extra == 'jax'
   - numba>=0.57 ; extra == 'numba'
+  - llvmlite ; extra == 'numba'
   - sphinx<6,>=5.1.0 ; extra == 'rtd'
   - pygments ; extra == 'rtd'
   - pydot ; extra == 'rtd'
@@ -9712,22 +9723,22 @@ packages:
   - coverage>=5.1 ; extra == 'tests'
   - pytest-benchmark ; extra == 'tests'
   - pytest-mock ; extra == 'tests'
+  - pytest-sphinx ; extra == 'tests'
   requires_python: <3.13,>=3.10
 - kind: pypi
   name: pytensor
-  version: 2.20.0
-  url: https://files.pythonhosted.org/packages/2f/d5/5996fdaabb5db7b9e5a626675129837548834e67fde1e6018e494135dba9/pytensor-2.20.0-cp312-cp312-macosx_10_9_x86_64.whl
-  sha256: 217e4cfbbea218e6244b46ce0816b2cf7d3152d35d9f1743a42d8bc302b07495
+  version: 2.25.5
+  url: https://files.pythonhosted.org/packages/77/99/f8f4a75e3287c48409dad5aa96336d10d76e9b4c9ebf5193b7436473ab2b/pytensor-2.25.5-cp312-cp312-macosx_10_13_x86_64.whl
+  sha256: f15cf74eff5e53854f9e74ac4991ae850e48641ccbb211200d214c599b76d691
   requires_dist:
-  - setuptools>=48.0.0
-  - scipy>=0.14
-  - numpy>=1.17.0
-  - filelock
+  - setuptools>=59.0.0
+  - scipy<2,>=1
+  - numpy<2,>=1.17.0
+  - filelock>=3.15
   - etuples
   - logical-unification
   - minikanren
   - cons
-  - typing-extensions
   - pytensor[jax] ; extra == 'complete'
   - pytensor[numba] ; extra == 'complete'
   - pytensor[complete] ; extra == 'development'
@@ -9736,6 +9747,7 @@ packages:
   - jax ; extra == 'jax'
   - jaxlib ; extra == 'jax'
   - numba>=0.57 ; extra == 'numba'
+  - llvmlite ; extra == 'numba'
   - sphinx<6,>=5.1.0 ; extra == 'rtd'
   - pygments ; extra == 'rtd'
   - pydot ; extra == 'rtd'
@@ -9747,22 +9759,22 @@ packages:
   - coverage>=5.1 ; extra == 'tests'
   - pytest-benchmark ; extra == 'tests'
   - pytest-mock ; extra == 'tests'
+  - pytest-sphinx ; extra == 'tests'
   requires_python: <3.13,>=3.10
 - kind: pypi
   name: pytensor
-  version: 2.20.0
-  url: https://files.pythonhosted.org/packages/f4/f9/e2ba08de027e1ccc4bec8f3f383a144f3df7d54af4660cea8f2fac00597d/pytensor-2.20.0.tar.gz
-  sha256: d88a5c84d04366d5224b5705a9d0daab7d9b0b84ed43c76fc9aae7760fe3eac2
+  version: 2.25.5
+  url: https://files.pythonhosted.org/packages/f5/11/032d9c2bb9bfa1b6d933c17a6fd063e075c533cca271d8c9b2055f94b981/pytensor-2.25.5-py2.py3-none-any.whl
+  sha256: 92271932118e4d9e6528eeba1cdd0e9e8f2d05d8493eb394da2cd8cf09c8836e
   requires_dist:
-  - setuptools>=48.0.0
-  - scipy>=0.14
-  - numpy>=1.17.0
-  - filelock
+  - setuptools>=59.0.0
+  - scipy<2,>=1
+  - numpy<2,>=1.17.0
+  - filelock>=3.15
   - etuples
   - logical-unification
   - minikanren
   - cons
-  - typing-extensions
   - pytensor[jax] ; extra == 'complete'
   - pytensor[numba] ; extra == 'complete'
   - pytensor[complete] ; extra == 'development'
@@ -9771,6 +9783,7 @@ packages:
   - jax ; extra == 'jax'
   - jaxlib ; extra == 'jax'
   - numba>=0.57 ; extra == 'numba'
+  - llvmlite ; extra == 'numba'
   - sphinx<6,>=5.1.0 ; extra == 'rtd'
   - pygments ; extra == 'rtd'
   - pydot ; extra == 'rtd'
@@ -9782,6 +9795,7 @@ packages:
   - coverage>=5.1 ; extra == 'tests'
   - pytest-benchmark ; extra == 'tests'
   - pytest-mock ; extra == 'tests'
+  - pytest-sphinx ; extra == 'tests'
   requires_python: <3.13,>=3.10
 - kind: conda
   name: python
@@ -11038,6 +11052,12 @@ packages:
   - pkg:pypi/terminado?source=hash-mapping
   size: 22717
   timestamp: 1710265922593
+- kind: pypi
+  name: threadpoolctl
+  version: 3.5.0
+  url: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
+  sha256: 56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467
+  requires_python: '>=3.8'
 - kind: conda
   name: tinycss2
   version: 1.3.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -183,7 +183,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.2-py312h58c1407_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.8-hedd0468_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
@@ -486,7 +486,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.1.2-py312h2eb110b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.2-h0d9d63b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openldap-2.6.8-h50f9a67_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.2-h86ecc28_0.conda
@@ -745,7 +745,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.2-py312he4d506f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
@@ -977,7 +977,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.2-py312h801f5e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
@@ -1549,22 +1549,6 @@ packages:
   - pkg:pypi/babel?source=hash-mapping
   size: 7609750
   timestamp: 1702422720584
-- kind: pypi
-  name: bayesian-pyhf
-  version: 0.1.dev321
-  url: git+https://github.com/malin-horstmann/bayesian_pyhf.git@95cf01f37c613974c8962adf9e0bb510d126f728
-  requires_dist:
-  - jax>=0.4.2
-  - jaxlib>=0.4.2
-  - matplotlib>=3.6.3
-  - numpy
-  - pyhf>=0.7.0
-  - pymc>=5.0.2
-  - pytensor
-  - coverage[toml]>=6.0.0 ; extra == 'test'
-  - pytest-mock ; extra == 'test'
-  - pytest>=6.0 ; extra == 'test'
-  requires_python: '>=3.7'
 - kind: pypi
   name: bayesian-pyhf
   version: 0.1.dev321
@@ -2882,15 +2866,6 @@ packages:
   - pkg:pypi/entrypoints?source=hash-mapping
   size: 9199
   timestamp: 1643888357950
-- kind: pypi
-  name: etuples
-  version: 0.3.9
-  url: https://files.pythonhosted.org/packages/22/60/134940a09d03786ad7267e53458a749e2f4bfaf1efd672363e87a4a13561/etuples-0.3.9.tar.gz
-  sha256: a474e586683d8ba8d842ba29305005ceed1c08371a4b4b0e0e232527137e5ea3
-  requires_dist:
-  - cons
-  - multipledispatch
-  requires_python: '>=3.8'
 - kind: pypi
   name: etuples
   version: 0.3.9
@@ -7782,15 +7757,6 @@ packages:
   - multipledispatch
   requires_python: '>=3.6'
 - kind: pypi
-  name: logical-unification
-  version: 0.4.6
-  url: https://files.pythonhosted.org/packages/c0/73/8dac224c46949e61bc52558384138a2b79fa0b7be10367074862fe9994dd/logical-unification-0.4.6.tar.gz
-  sha256: 908435123f8a106fa4dcf9bf1b75c7beb309fa2bbecf277868af8f1c212650a0
-  requires_dist:
-  - toolz
-  - multipledispatch
-  requires_python: '>=3.6'
-- kind: pypi
   name: markdown-it-py
   version: 3.0.0
   url: https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl
@@ -8147,18 +8113,6 @@ packages:
   url: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
   sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
   requires_python: '>=3.7'
-- kind: pypi
-  name: minikanren
-  version: 1.0.3
-  url: https://files.pythonhosted.org/packages/c8/21/1be8af0ecaf5a61abebabc8dabf63a08d72334ced5bb9f9d027fd7abbf42/miniKanren-1.0.3.tar.gz
-  sha256: 1ec8bdb01144ad5e8752c7c297fb8a122db920f859276d25a72d164e998d7f6e
-  requires_dist:
-  - toolz
-  - cons>=0.4.0
-  - multipledispatch
-  - etuples>=0.3.1
-  - logical-unification>=0.4.1
-  requires_python: '>=3.6'
 - kind: pypi
   name: minikanren
   version: 1.0.3
@@ -8540,18 +8494,18 @@ packages:
   timestamp: 1707957948029
 - kind: conda
   name: numpy
-  version: 2.1.2
-  build: py312h2eb110b_0
+  version: 1.26.4
+  build: py312h470d778_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.1.2-py312h2eb110b_0.conda
-  sha256: eba7ea647685325e7c09d4c4445047d36e754e2444389c8b6aa41e8a4171216c
-  md5: 548aab48a0d2bf1a2a6a6542b4fd3c7c
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
+  sha256: 23767677a7790bee5457d5e75ebd508b9a31c5354216f4310dd1acfca3f7a6f9
+  md5: 9cebf5a06cb87d4569cd68df887af476
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libgcc >=13
+  - libgcc-ng >=12
   - liblapack >=3.9.0,<4.0a0
-  - libstdcxx >=13
+  - libstdcxx-ng >=12
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -8561,46 +8515,20 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/numpy?source=hash-mapping
-  size: 7129746
-  timestamp: 1728240412984
+  size: 6614296
+  timestamp: 1707225994762
 - kind: conda
   name: numpy
-  version: 2.1.2
-  build: py312h58c1407_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.2-py312h58c1407_0.conda
-  sha256: 598603f9aba1a5f06d11c45fe3d25ffa5d19eb44e99244310693fdaed3538865
-  md5: b7e9a46277a1ee0afc6311e7760df0c3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc >=13
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/numpy?source=hash-mapping
-  size: 8447869
-  timestamp: 1728240376876
-- kind: conda
-  name: numpy
-  version: 2.1.2
-  build: py312h801f5e3_0
+  version: 1.26.4
+  build: py312h8442bc7_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.2-py312h801f5e3_0.conda
-  sha256: 7e6840963d5395a59cb0aca32d43fd4e539c00a0677fcad16e4a3ab1f5c7aab7
-  md5: 3f9101c02190f155b6525490238fc794
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
+  sha256: c8841d6d6f61fd70ca80682efbab6bdb8606dc77c68d8acabfbd7c222054f518
+  md5: d83fc83d589e2625a3451c9a7e21047c
   depends:
-  - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=17
+  - libcxx >=16
   - liblapack >=3.9.0,<4.0a0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
@@ -8611,21 +8539,20 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/numpy?source=hash-mapping
-  size: 6436873
-  timestamp: 1728240394809
+  size: 6073136
+  timestamp: 1707226249608
 - kind: conda
   name: numpy
-  version: 2.1.2
-  build: py312he4d506f_0
+  version: 1.26.4
+  build: py312he3a82b2_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.1.2-py312he4d506f_0.conda
-  sha256: 23e0df322c9ca76375d98ff85d4b901477894969dd15db1ceb17c64434c57f82
-  md5: f3fd3efe976ed50ae5b5b0921cbf497f
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
+  sha256: 6152b73fba3e227afa4952df8753128fc9669bbaf142ee8f9972bf9df3bf8856
+  md5: 96c61a21c4276613748dba069554846b
   depends:
-  - __osx >=10.13
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=17
+  - libcxx >=16
   - liblapack >=3.9.0,<4.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -8635,8 +8562,32 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/numpy?source=hash-mapping
-  size: 7466638
-  timestamp: 1728240348311
+  size: 6990646
+  timestamp: 1707226178262
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py312heda63a1_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+  sha256: fe3459c75cf84dcef6ef14efcc4adb0ade66038ddd27cadb894f34f4797687d8
+  md5: d8285bea2a350f63fab23bf460221f3f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  size: 7484186
+  timestamp: 1707225809722
 - kind: conda
   name: openjpeg
   version: 2.5.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -18,7 +18,7 @@ iminuit = ">=2.30.1,<3"
 uproot = ">=5.4.1,<6"
 ipympl = ">=0.9.4,<0.10"
 corner = ">=2.1.0,<3"
-numpy = ">=2.1.2,<3"
+numpy = ">=1.17.0,<2"
 
 [pypi-dependencies]
 bayesian-pyhf = { git = "https://github.com/malin-horstmann/bayesian_pyhf.git" }


### PR DESCRIPTION
Resolves #2 

* PyTensor currently does not support NumPy v2.0 and so NumPy v1.x releases can be used.
* Resolve the lock file fully to get the latest pytensor available.

> [!NOTE] 
> Note that I haven't verified at time of opening this PR if `pytensor` `v2.25.5` is compatible with the tutorial, but
> 
> ```console
> $ pixi run jupyter execute 03-bayesian-pyhf.ipynb
> [NbClientApp] Executing 03-bayesian-pyhf.ipynb
> [NbClientApp] Executing notebook with kernel: python3
> $ echo $?
> 0
> ```
>
> runs without errors (or at least non-zero exit codes).